### PR TITLE
http/https proxy supporting

### DIFF
--- a/push/authention/auth.go
+++ b/push/authention/auth.go
@@ -52,7 +52,12 @@ func NewAuthClient(conf *config.Config) (*AuthClient, error) {
 		return nil, errors.New("appId or appSecret is null")
 	}
 
-	c, err := httpclient.NewHTTPClient()
+	httpClientCfg, err := httpclient.NewHTTPClientConfig(conf)
+	if err != nil {
+		return nil, err
+	}
+
+	c, err := httpclient.NewHTTPClient(httpClientCfg)
 	if err != nil {
 		return nil, errors.New("failed to get http client")
 	}

--- a/push/config/config.go
+++ b/push/config/config.go
@@ -16,9 +16,15 @@ Copyright 2020. Huawei Technologies Co., Ltd. All rights reserved.
 
 package config
 
+import "time"
+
 type Config struct {
-	AppId     string
-	AppSecret string
-	AuthUrl   string
-	PushUrl   string
+	AppId               string
+	AppSecret           string
+	AuthUrl             string
+	PushUrl             string
+	HttpProxyUrl        string
+	HttpProxyCACertPath string
+	MaxRetryTimes       int
+	RetryInterval       time.Duration
 }

--- a/push/core/pushclient.go
+++ b/push/core/pushclient.go
@@ -21,9 +21,10 @@ import (
 	"encoding/json"
 	"errors"
 	"fmt"
-	"github.com/msalihkarakasli/go-hms-push/push/authention"
-	"github.com/msalihkarakasli/go-hms-push/push/config"
 	"reflect"
+
+	auth "github.com/msalihkarakasli/go-hms-push/push/authention"
+	"github.com/msalihkarakasli/go-hms-push/push/config"
 
 	"github.com/msalihkarakasli/go-hms-push/httpclient"
 	"github.com/msalihkarakasli/go-hms-push/push/constant"
@@ -48,7 +49,12 @@ func NewHttpClient(c *config.Config) (*HMSClient, error) {
 		return nil, errors.New("pushUrl can't be empty")
 	}
 
-	client, err := httpclient.NewHTTPClient()
+	httpClientCfg, err := httpclient.NewHTTPClientConfig(c)
+	if err != nil {
+		return nil, err
+	}
+
+	client, err := httpclient.NewHTTPClient(httpClientCfg)
 	if err != nil {
 		return nil, errors.New("failed to get http client")
 	}


### PR DESCRIPTION
example of setting a http/https proxy:

```
        var conf = config.Config{
		AppId:               opts.AppId,
		AppSecret:           opts.AppSecret,
		AuthUrl:             opts.AuthUrl,
		PushUrl:             opts.PushUrl,
		HttpProxyUrl:        opts.HttpProxyUrl,
		HttpProxyCACertPath: opts.ProxyCACertPath,
		MaxRetryTimes:       1,
		RetryInterval:       0,
	}

	client, err := core.NewHttpClient(&conf)
```

