### PR TITLE
Set auth header after token refresh

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/msalihkarakasli/go-hms-push
+module github.com/stefrerichs/go-hms-push
 
 go 1.14

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/stefrerichs/go-hms-push
+module github.com/msalihkarakasli/go-hms-push
 
 go 1.14

--- a/push/core/message.go
+++ b/push/core/message.go
@@ -61,10 +61,18 @@ func (c *HMSClient) getSendMsgRequest(msgRequest *model.MessageRequest) (*httpcl
 		Method: http.MethodPost,
 		URL:    fmt.Sprintf(constant.SendMessageFmt, c.endpoint, c.appId),
 		Body:   body,
-		Header: []httpclient.HTTPOption{
-			httpclient.SetHeader("Content-Type", "application/json;charset=utf-8"),
-			httpclient.SetHeader("Authorization", "Bearer "+c.token),
-		},
+		Header: getMsgHeader(c),
 	}
 	return request, nil
+}
+
+func (c *HMSClient) updateHeader(request *httpclient.PushRequest) {
+	request.Header = getMsgHeader(c)
+}
+
+func getMsgHeader(c *HMSClient) []httpclient.HTTPOption {
+	return []httpclient.HTTPOption{
+		httpclient.SetHeader("Content-Type", "application/json;charset=utf-8"),
+		httpclient.SetHeader("Authorization", "Bearer "+c.token),
+	}
 }

--- a/push/core/pushclient.go
+++ b/push/core/pushclient.go
@@ -99,6 +99,7 @@ func (c *HMSClient) executeApiOperation(ctx context.Context, request *httpclient
 	}
 
 	if retry {
+		c.updateHeader(request)
 		err = c.sendHttpRequest(ctx, request, responsePointer)
 		return err
 	}


### PR DESCRIPTION
The auth header has not been updated after token refresh, so every retry failed with expired token error.