### PR TITLE
removed omitempty json tag from ForegroundShow field

### DIFF
--- a/push/model/message_hm.go
+++ b/push/model/message_hm.go
@@ -65,11 +65,11 @@ type AndroidNotification struct {
 	VibrateConfig     []string           `json:"vibrate_config,omitempty"`
 	Visibility        string             `json:"visibility,omitempty"`
 	LightSettings     *LightSettings     `json:"light_settings,omitempty"`
-	ForegroundShow    bool               `json:"foreground_show,omitempty"`
+	ForegroundShow    bool               `json:"foreground_show"`
 }
 
 type ClickAction struct {
-	Type         int    `json:"type"` //when the type equals to 1, At least one of intent and action is not empty
+	Type         int    `json:"type"` // when the type equals to 1, At least one of intent and action is not empty
 	Intent       string `json:"intent,omitempty"`
 	Action       string `json:"action,omitempty"`
 	Url          string `json:"url,omitempty"`


### PR DESCRIPTION
HMS PushKit ForegroundShow defaults to `true` so this field should be sent explicity with `false` in order to don't display a notification when the app is in foreground